### PR TITLE
Add in-memory dataset, refactor dataset classes

### DIFF
--- a/robustnessgym/core/cachedops.py
+++ b/robustnessgym/core/cachedops.py
@@ -109,14 +109,17 @@ class CachedOperation(Operation):
                     # self
                     target_ident_key = str(self_or_cls.identifier)
 
-                # TODO(karan): iterate over all keys and pick the best match,
-                #  rather than breaking
+                best_match, best_distance = None, 100000000
                 for ident_key in batch["cache"][0].keys():
-                    # Pick the first key that matches the cls name or instance
-                    # identifier
-                    if ident_key.startswith(target_ident_key):
-                        identifier = ident_key
-                        break
+                    # Pick the key that best matches the cls name or instance identifier
+                    if (
+                        ident_key.startswith(target_ident_key)
+                        and len(ident_key.replace(target_ident_key, "")) < best_distance
+                    ):
+                        best_match = ident_key
+                        best_distance = len(ident_key.replace(target_ident_key, ""))
+
+                identifier = best_match
 
                 # Still no identifier
                 if not identifier:
@@ -336,7 +339,10 @@ class CachedOperation(Operation):
         return self.store(batch=batch, updates=updates)
 
     def process_dataset(
-        self, dataset: Dataset, columns: List[str], batch_size: int = 32
+        self,
+        dataset: Dataset,
+        columns: List[str],
+        batch_size: int = 32,
     ) -> Dataset:
         """Apply the cached operation to a dataset."""
 

--- a/robustnessgym/core/dataformats/abstract.py
+++ b/robustnessgym/core/dataformats/abstract.py
@@ -1,0 +1,36 @@
+"""File containing abstract base class for datasets."""
+import abc
+
+from datasets.arrow_dataset import DatasetInfoMixin
+
+
+class AbstractDataset(
+    abc.ABC,
+    DatasetInfoMixin,
+):
+    """An abstract dataset class."""
+
+    def __init__(self, *args, **kwargs):
+        super(AbstractDataset, self).__init__(*args, **kwargs)
+
+    def __repr__(self):
+        return (
+            f"RobustnessGym{self.__class__.__name__}"
+            f"(num_rows: {self._dataset.num_rows})"
+        )
+
+    @abc.abstractmethod
+    def __len__(self):
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def num_rows(self):
+        """Number of total rows in the dataset."""
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def columns(self):
+        """Columns in the dataset."""
+        raise NotImplementedError

--- a/robustnessgym/core/dataformats/inmemory.py
+++ b/robustnessgym/core/dataformats/inmemory.py
@@ -1,0 +1,553 @@
+from __future__ import annotations
+
+import gzip
+import os
+import pickle
+from types import SimpleNamespace
+from typing import Callable, Dict, List, Mapping, Optional, Union
+
+import cytoolz as tz
+import datasets
+import pyarrow as pa
+from datasets import DatasetInfo, Features, NamedSplit
+
+from robustnessgym.core.dataformats.abstract import AbstractDataset
+from robustnessgym.core.tools import recmerge
+
+Example = Dict
+Batch = Dict[str, List]
+
+
+class InMemoryDataset(AbstractDataset):
+    """Class for datasets that are to be stored in memory."""
+
+    def __init__(
+        self,
+        *args,
+        column_names: List[str] = None,
+        info: DatasetInfo = None,
+        split: Optional[NamedSplit] = None,
+    ):
+
+        # Data is a dictionary of lists
+        self._data = {}
+
+        # Single argument
+        if len(args) == 1:
+            assert column_names is None, "Don't pass in column_names."
+            # The data is passed in
+            data = args[0]
+
+            # `data` is a dictionary
+            if isinstance(data, dict) and len(data):
+                # Assert all columns are the same length
+                self._assert_columns_all_equal_length(data)
+                self._data = data
+
+            # `data` is a list
+            elif isinstance(data, list) and len(data):
+                # Transpose the list of dicts to a dict of lists i.e. a batch
+                data = tz.merge_with(list, *data)
+                # Assert all columns are the same length
+                self._assert_columns_all_equal_length(data)
+                self._data = data
+
+            # `data` is a datasets.Dataset
+            elif isinstance(data, datasets.Dataset):
+                self._data = data[:]
+                info, split = data.info, data.split
+
+        # No argument
+        elif len(args) == 0:
+
+            # Use column_names to setup the data dictionary
+            if column_names:
+                self._data = {k: [] for k in column_names}
+
+        # Setup the DatasetInfo
+        info = info.copy() if info is not None else DatasetInfo()
+        AbstractDataset.__init__(self, info=info, split=split)
+
+        # Create attributes for all columns and visible columns
+        self.all_columns = list(self._data.keys())
+        self.visible_columns = None
+
+        # Initialization
+        self._initialize_state()
+
+    def _initialize_state(self):
+        """Dataset state initialization."""
+        # Show all columns by default
+        self.visible_columns = self.all_columns
+
+        # Set the features
+        self._set_features()
+
+    def _set_features(self):
+        """Set the features of the dataset."""
+        self.info.features = Features.from_arrow_schema(
+            pa.Table.from_pydict(
+                self[:1],
+            ).schema
+        )
+
+    def __repr__(self):
+        return self.__class__.__name__
+
+    @classmethod
+    def _assert_columns_all_equal_length(cls, batch: Batch):
+        """Check that all columns have the same length so that the data is
+        tabular."""
+        assert cls._columns_all_equal_length(
+            batch
+        ), "All columns must have equal length."
+
+    @classmethod
+    def _columns_all_equal_length(cls, batch: Batch):
+        """Check that all columns have the same length so that the data is
+        tabular."""
+        if len(set([len(v) for k, v in batch.items()])) == 1:
+            return True
+        return False
+
+    def _check_columns_exist(self, columns: List[str]):
+        """Check that every column in `columns` exists."""
+        for col in columns:
+            assert col in self.all_columns, f"{col} is not a valid column."
+
+    @property
+    def column_names(self):
+        """Column names in the dataset."""
+        return self.all_columns
+
+    @property
+    def columns(self):
+        """Column names in the dataset."""
+        return self.column_names
+
+    @property
+    def num_rows(self):
+        """Number of rows in the dataset."""
+        return len(self)
+
+    def set_format(self, columns: List[str]):
+        """Set the dataset format.
+
+        Only `columns` are visible after set_format is invoked.
+        """
+        # Check that the columns exist
+        self._check_columns_exist(columns)
+
+        # Set visible columns
+        self.visible_columns = columns
+
+    def reset_format(self):
+        """Reset the dataset format.
+
+        All columns are visible.
+        """
+        # All columns are visible
+        self.visible_columns = self.all_columns
+        # TODO(karan): all_columns should be updated if a column is added by map
+
+    def batch(self, batch_size: int = 32, drop_last_batch: bool = False):
+        """Batch the dataset.
+
+        Args:
+            batch_size: integer batch size
+            drop_last_batch: drop the last batch if its smaller than batch_size
+
+        Returns:
+            batches of data
+        """
+        for i in range(0, len(self), batch_size):
+            if drop_last_batch and i + batch_size > len(self):
+                continue
+            yield self[i : i + batch_size]
+
+    def _example_or_batch_to_batch(
+        self, example_or_batch: Union[Example, Batch]
+    ) -> Batch:
+
+        # Check if example_or_batch is a batch
+        is_batch = all(
+            [isinstance(v, List) for v in example_or_batch.values()]
+        ) and self._columns_all_equal_length(example_or_batch)
+
+        # Convert to a batch if not
+        if not is_batch:
+            batch = {k: [v] for k, v in example_or_batch.items()}
+        else:
+            batch = example_or_batch
+
+        return batch
+
+    def _append_to_empty_dataset(self, example_or_batch: Union[Example, Batch]) -> None:
+        """Append a batch of data to the dataset when it's empty."""
+        # Convert to batch
+        batch = self._example_or_batch_to_batch(example_or_batch)
+
+        # Dataset is empty: just assign it to the batch
+        self._data = batch
+        # TODO(karan): what other data properties need to be in sync here
+        self.all_columns = self.visible_columns = list(self._data.keys())
+
+    def append(
+        self,
+        example_or_batch: Union[Example, Batch],
+    ) -> None:
+        """Append a batch of data to the dataset.
+
+        `batch` must have the same columns as the dataset (regardless of
+        what columns are visible).
+        """
+        if not self.column_names:
+            return self._append_to_empty_dataset(example_or_batch)
+
+        # Check that example_or_batch has the same format as the dataset
+        # TODO(karan): require matching on nested features?
+        columns = list(example_or_batch.keys())
+        assert set(columns) == set(
+            self.column_names
+        ), f"Mismatched columns\nbatch: {columns}\ndataset: {self.column_names}"
+
+        # Convert to a batch
+        batch = self._example_or_batch_to_batch(example_or_batch)
+
+        # Append to the dataset
+        for k in self.column_names:
+            self._data[k].extend(batch[k])
+
+    def __len__(self):
+        # Pick any column
+        column_names = self.column_names
+        if column_names:
+            return len(self._data[column_names[0]])
+        return 0
+
+    def __getitem__(self, index):
+        if isinstance(index, int) or isinstance(index, slice):
+            return {k: self._data[k][index] for k in self.visible_columns}
+        elif isinstance(index, tuple):
+            raise NotImplementedError("Tuple as index")
+        elif isinstance(index, str):
+            if index in self.column_names:
+                return self._data[index]
+            raise AttributeError(f"Column {index} does not exist.")
+        elif isinstance(index, list) and len(index):
+            return {k: [self._data[k][i] for i in index] for k in self.visible_columns}
+        else:
+            raise TypeError("Invalid argument type: {}".format(type(index)))
+
+    @classmethod
+    def from_batch(cls, batch: Batch):
+        """Create an InMemoryDataset from a batch."""
+        return cls(batch)
+
+    @classmethod
+    def from_batches(cls, batches: List[Batch]):
+        """Create an InMemoryDataset from a list of batches."""
+        return cls.from_batch(
+            tz.merge_with(tz.concat, *batches),
+        )
+
+    def select_columns(self, columns: List[str]) -> Batch:
+        """Select a subset of columns."""
+        for col in columns:
+            assert col in self._data
+        return tz.keyfilter(lambda k: k in columns, self._data)
+
+    def _inspect_function(
+        self,
+        function: Callable,
+        with_indices: bool = False,
+        batched: bool = False,
+    ) -> SimpleNamespace:
+
+        # Initialize
+        no_output = dict_output = bool_output = False
+
+        # Run the function to test it
+        if batched:
+            if with_indices:
+                output = function(self[:2], range(2))
+            else:
+                output = function(self[:2])
+
+        else:
+            if with_indices:
+                output = function(self[0], 0)
+            else:
+                output = function(self[0])
+
+        if isinstance(output, Mapping):
+            dict_output = True
+        elif output is None:
+            no_output = True
+        elif isinstance(output, bool):
+            bool_output = True
+        else:
+            raise ValueError("function must return a dict or None.")
+
+        return SimpleNamespace(
+            dict_output=dict_output,
+            no_output=no_output,
+            bool_output=bool_output,
+        )
+
+    @classmethod
+    def _merge_batch_and_output(cls, batch: Batch, output: Batch):
+        """Merge an output during .map() into a batch."""
+        combined = batch
+        for k in output.keys():
+            if k not in batch:
+                combined[k] = output[k]
+            else:
+                if isinstance(batch[k][0], dict) and isinstance(output[k][0], dict):
+                    combined[k] = [
+                        recmerge(b_i, o_i) for b_i, o_i in zip(batch[k], output[k])
+                    ]
+                else:
+                    combined[k] = output[k]
+        return combined
+
+    def map(
+        self,
+        function: Optional[Callable] = None,
+        with_indices: bool = False,
+        input_columns: Optional[Union[str, List[str]]] = None,
+        batched: bool = False,
+        batch_size: Optional[int] = 1000,
+        drop_last_batch: bool = False,
+        remove_columns: Optional[List[str]] = None,
+        # keep_in_memory: bool = False,
+        #             # load_from_cache_file: bool = True,
+        cache_file_name: Optional[str] = None,
+        #             # writer_batch_size: Optional[int] = 1000,
+        #             # features: Optional[Features] = None,
+        #             # disable_nullable: bool = False,
+        #             # fn_kwargs: Optional[dict] = None,
+        #             # num_proc: Optional[int] = None,
+        #             # suffix_template: str = "_{rank:05d}_of_{num_proc:05d}",
+        #             # new_fingerprint: Optional[str] = None,
+        required_columns: Optional[List[str]] = None,
+        **kwargs,
+    ) -> Optional[InMemoryDataset]:
+
+        # Set the function if it's None
+        if function is None:
+            function = (lambda x, index: x) if with_indices else lambda x: x
+
+        if isinstance(input_columns, str):
+            input_columns = [input_columns]
+
+        # Set the format
+        if input_columns:
+            previous_format = self.visible_columns
+            self.set_format(input_columns)
+
+        # Get some information about the function
+        function_properties = self._inspect_function(function, with_indices, batched)
+        update_dataset = function_properties.dict_output
+
+        # Return if `self` has no examples
+        if not len(self):
+            return self if update_dataset else None
+
+        # Map returns a new dataset if the function returns a dict
+        if update_dataset:
+            new_dataset = InMemoryDataset()
+
+        # Run the map
+        if batched:
+            for i, batch in enumerate(self.batch(batch_size, drop_last_batch)):
+                output = (
+                    function(
+                        batch,
+                        range(i * batch_size, min(len(self), (i + 1) * batch_size)),
+                    )
+                    if with_indices
+                    else function(batch)
+                )
+
+                if update_dataset:
+                    # TODO(karan): check that this has the correct behavior
+                    output = self._merge_batch_and_output(batch, output)
+                    # output = recmerge(batch, output, merge_sequences=True)
+                    new_dataset.append(output)
+
+        else:
+            for i, example in enumerate(self):
+                output = function(example, i) if with_indices else function(example)
+
+                if update_dataset:
+                    # TODO(karan): check that this has the correct behavior
+                    output = recmerge(example, output)
+                    new_dataset.append(output)
+
+        # Reset the format
+        if input_columns:
+            self.set_format(previous_format)
+
+        if update_dataset:
+            new_dataset._set_features()
+            return new_dataset
+        return None
+
+    @classmethod
+    def _mask_batch(cls, batch: Batch, boolean_mask: List[bool]):
+        """Remove elements in `batch` that are masked by `boolean_mask`."""
+        return {
+            k: [e for i, e in enumerate(v) if boolean_mask[i]] for k, v in batch.items()
+        }
+
+    def filter(
+        self,
+        function: Optional[Callable] = None,
+        with_indices=False,
+        input_columns: Optional[Union[str, List[str]]] = None,
+        batch_size: Optional[int] = 1000,
+        remove_columns: Optional[List[str]] = None,
+        # keep_in_memory: bool = False,
+        # load_from_cache_file: bool = True,
+        cache_file_name: Optional[str] = None,
+        # writer_batch_size: Optional[int] = 1000,
+        # fn_kwargs: Optional[dict] = None,
+        # num_proc: Optional[int] = None,
+        # suffix_template: str = "_{rank:05d}_of_{num_proc:05d}",
+        # new_fingerprint: Optional[str] = None,
+        **kwargs,
+    ):
+        # Set the function if it's None
+        if function is None:
+            function = lambda *args, **kwargs: True
+
+        if isinstance(input_columns, str):
+            input_columns = [input_columns]
+
+        # Set the format
+        if input_columns:
+            previous_format = self.visible_columns
+            self.set_format(input_columns)
+
+        # Get some information about the function
+        # TODO(karan): extend to handle batched functions
+        function_properties = self._inspect_function(
+            function,
+            with_indices,
+            batched=False,
+        )
+        assert function_properties.bool_output, "function must return boolean."
+
+        # Run the filter
+        indices = []
+        for i, example in enumerate(self):
+            output = (
+                function(
+                    example,
+                    i,
+                )
+                if with_indices
+                else function(example)
+            )
+            assert isinstance(output, bool), "function must return boolean."
+
+            # Add in the index
+            if output:
+                indices.append(i)
+
+        # Reset the format, to set visible columns for the filter
+        self.reset_format()
+
+        # Filter returns a new dataset
+        new_dataset = InMemoryDataset()
+        if indices:
+            new_dataset = InMemoryDataset.from_batch(self[indices])
+
+        # Set the format back to what it was before the filter was applied
+        if input_columns:
+            self.set_format(previous_format)
+
+        return new_dataset
+
+    @classmethod
+    def _state_keys(cls) -> set:
+        """List of attributes that describe the state of the object."""
+        return {"_data", "all_columns", "_info", "_split"}
+
+    @classmethod
+    def _assert_state_keys(cls, state: Dict) -> None:
+        """Assert that a state contains all required keys."""
+        assert (
+            set(state.keys()) == cls._state_keys()
+        ), f"State must contain all state keys: {cls._state_keys()}."
+
+    def __getstate__(self) -> Dict:
+        """Get the internal state of the dataset."""
+        state = {key: getattr(self, key) for key in self._state_keys()}
+        self._assert_state_keys(state)
+        return state
+
+    def __setstate__(self, state: Dict) -> None:
+        """Set the internal state of the dataset."""
+        if not isinstance(state, dict):
+            raise ValueError(
+                f"`state` must be a dictionary containing " f"{self._state_keys()}."
+            )
+
+        self._assert_state_keys(state)
+
+        for key in self._state_keys():
+            setattr(self, key, state[key])
+
+        # Do some initialization
+        self._initialize_state()
+
+    @classmethod
+    def load_from_disk(cls, path: str) -> InMemoryDataset:
+        """Load the in-memory dataset from disk."""
+
+        with gzip.open(os.path.join(path, "data.gz")) as f:
+            dataset = pickle.load(f)
+        # # Empty state dict
+        # state = {}
+        #
+        # # Load the data
+        # with gzip.open(os.path.join(path, "data.gz")) as f:
+        #     state['_data'] = pickle.load(f)
+        #
+        # # Load the metadata
+        # metadata = json.load(
+        #     open(os.path.join(path, "metadata.json"))
+        # )
+        #
+        # # Merge the metadata into the state
+        # state = {**state, **metadata}
+
+        # Create an empty `InMemoryDataset` and set its state
+        # dataset = cls()
+        # dataset.__setstate__(state)
+
+        return dataset
+
+    def save_to_disk(self, path: str):
+        """Save the in-memory dataset to disk."""
+        # Create all the directories to the path
+        os.makedirs(path, exist_ok=True)
+
+        # Store the data in a compressed format
+        with gzip.open(os.path.join(path, "data.gz"), "wb") as f:
+            pickle.dump(self, f)
+
+        # # Get the dataset state
+        # state = self.__getstate__()
+        #
+        # # Store the data in a compressed format
+        # with gzip.open(os.path.join(path, "data.gz"), "wb") as f:
+        #     pickle.dump(state['_data'], f)
+        #
+        # # Store the metadata
+        # json.dump(
+        #     {k: v for k, v in state.items() if k != '_data'},
+        #     open(os.path.join(path, "metadata.json"), 'w'),
+        # )

--- a/robustnessgym/core/identifier.py
+++ b/robustnessgym/core/identifier.py
@@ -26,18 +26,22 @@ class Identifier:
 
     @property
     def name(self):
+        """Base name."""
         return self._name
 
     @property
     def index(self):
+        """Index associated with the identifier."""
         return self._index
 
     @property
     def parameters(self):
+        """Additional parameters contained in the identifier."""
         return self._parameters
 
     @classmethod
     def range(cls, n: int, _name: str, **kwargs) -> List[Identifier]:
+        """Create a list of identifiers, with index varying from 1 to `n`."""
 
         if n > 1:
             return [cls(_name=_name, _index=i, **kwargs) for i in range(1, n + 1)]
@@ -56,14 +60,16 @@ class Identifier:
     def __hash__(self):
         return persistent_hash(str(self))
 
-    def __eq__(self, other):
+    def __eq__(self, other: Union[Identifier, str]):
         return str(self) == str(other)
 
     def dumps(self):
+        """Dump the identifier to JSON."""
         return json.dumps(self.__dict__)
 
     @classmethod
     def loads(cls, s: str):
+        """Load the identifier from JSON."""
         identifier = Identifier(_name="")
         identifier.__dict__ = json.loads(s)
         return identifier

--- a/robustnessgym/core/slice.py
+++ b/robustnessgym/core/slice.py
@@ -9,35 +9,42 @@ from robustnessgym.core.identifier import Identifier
 
 
 class Slice(Dataset):
-    def __init__(
-        self, *args, identifier: str = None, dataset: Dataset = None, **kwargs
-    ):
+    """Slice class in Robustness Gym."""
 
-        if dataset is not None:
-            # Create a Slice directly from the Dataset object
-            self.__dict__ = dataset.__dict__.copy()
+    def __init__(
+        self,
+        *args,
+        identifier: Identifier = None,
+        **kwargs,
+    ):
+        # Set the identifier
+        self._identifier = identifier
+
+        # A slice has a lineage
+        self.lineage = []
+
+        # Set the category of the slice: defaults to 'curated'
+        self.category = CURATION
+
+        # Create a Slice directly from a Dataset
+        if len(args) == 1 and isinstance(args[0], Dataset):
+            # Update with the dataset info
+            dataset = args[0]
+            self.__dict__.update(dataset.__dict__)
             self._identifier = identifier or dataset.identifier
             self.lineage = [(str(Dataset.__name__), dataset.identifier)]
         else:
             super(Slice, self).__init__(*args, **kwargs)
 
-            # Set the identifier
-            self._identifier = identifier
-
-            # A slice has a lineage
-            self.lineage = []
-
-        # Set the category of the slice: defaults to 'curated'
-        self.category = CURATION
-
     def __repr__(self):
         return (
-            f"{self.__class__.__name__}[category: {self.category}, "
+            f"RobustnessGym{self.__class__.__name__}["
             f"num_rows: {self.num_rows}]({self.identifier})"
         )
 
     @property
     def identifier(self):
+        """Slice identifier."""
         if self._identifier:
             return self._identifier
         if self.lineage:
@@ -57,8 +64,62 @@ class Slice(Dataset):
 
     @identifier.setter
     def identifier(self, value):
+        """Set the slice's identifier."""
         self._identifier = value
 
     @classmethod
     def from_dataset(cls, dataset: Dataset):
-        return cls(dataset=dataset)
+        """Create a slice from a dataset."""
+        return cls(dataset)
+
+    @classmethod
+    def _state_keys(cls) -> set:
+        """List of attributes that describe the state of the object."""
+        dataset_state_keys = super(Slice, cls)._state_keys()
+        return dataset_state_keys.union(
+            {
+                "lineage",
+                "category",
+            }
+        )
+
+    def __getstate__(self):
+        """Get the current state of the slice."""
+
+        dataset_state = super(Slice, self).__getstate__()
+        state = {
+            **dataset_state,
+            **{
+                "lineage": [
+                    tuple(t[:1])
+                    + (t[1].dumps(),)
+                    + (tuple(t[2:]) if len(t) > 2 else ())
+                    for t in self.lineage
+                ],
+                "category": self.category,
+            },
+        }
+        self._assert_state_keys(state)
+
+        return state
+
+    def __setstate__(self, state):
+        """Set the current state of the slice."""
+        # Check that the state contains all keys
+        self._assert_state_keys(state)
+
+        # Load the lineage
+        self.lineage = [
+            tuple(t[:1])
+            + (Identifier.loads(t[1]),)
+            + (tuple(t[2:]) if len(t) > 2 else ())
+            for t in state["lineage"]
+        ]
+
+        # Load the category
+        self.category = state["category"]
+
+        # Set the dataset state: pick out state keys that correspond to the Dataset
+        super(Slice, self).__setstate__(
+            {k: v for k, v in state.items() if k in super(Slice, self)._state_keys()}
+        )

--- a/robustnessgym/core/storage.py
+++ b/robustnessgym/core/storage.py
@@ -1,15 +1,17 @@
-import dill as pickle
+import dill
 
 
 class StorageMixin:
+    """Mixin class for serialization."""
+
     def __init__(self, *args, **kwargs):
         super(StorageMixin, self).__init__(*args, **kwargs)
 
     def save(self, path: str) -> None:
         """Save the object."""
-        pickle.dump(self, open(path, "wb"))
+        dill.dump(self, open(path, "wb"))
 
     @classmethod
-    def load(cls, path: str):
+    def load(cls, path: str) -> object:
         """Load the object from the path."""
-        return pickle.load(open(path, "rb"))
+        return dill.load(open(path, "rb"))

--- a/robustnessgym/core/tape.py
+++ b/robustnessgym/core/tape.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+from typing import List, Union
+
+import cytoolz as tz
+
+from robustnessgym.core.constants import (
+    ATTACK,
+    CACHEDOPS,
+    SLICEBUILDERS,
+    SUBPOPULATION,
+    TRANSFORMATION,
+)
+from robustnessgym.core.identifier import Identifier
+from robustnessgym.core.tools import persistent_hash, strings_as_json
+
+
+class InteractionTape:
+    """Class for interaction tape to keep track of applied ops."""
+
+    def __init__(self):
+        # Keep track of the history
+        self.history = {}
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(interactions={len(self.history)})"
+
+    def __hash__(self):
+        val = 0
+        for (identifier, json_columns) in self.history:
+            val ^= persistent_hash(str(identifier) + str(json_columns))
+        return val
+
+    def dumps(self):
+        return json.dumps(
+            {
+                json.dumps((identifier.dumps(), json_columns)): idx
+                for (identifier, json_columns), idx in self.history.items()
+            }
+        )
+
+    @classmethod
+    def loads(cls, s: str):
+        tape = InteractionTape()
+        history = json.loads(s)
+        history = {
+            tuple(json.loads(json_tuple)): idx for json_tuple, idx in history.items()
+        }
+        tape.history = {
+            (Identifier.loads(identifier), json_columns): idx
+            for (identifier, json_columns), idx in history.items()
+        }
+
+        return tape
+
+    def update(self, identifier: Union[str, Identifier], columns: List[str]) -> None:
+        """Update the interaction tape with information about an interaction.
+
+        Args:
+            identifier: Identifier for the interaction used.
+            columns: list of columns on which the interaction was applied.
+
+        Returns: True if the interaction was added to the tape, False if it was
+        already applied before.
+        """
+        if isinstance(identifier, str):
+            identifier = Identifier(_name=identifier)
+        elif isinstance(identifier, Identifier):
+            pass
+        else:
+            raise ValueError(
+                f"Parameter `identifier` should be an instance of class Identifier "
+                f"or str, "
+                f"not {type(identifier)}."
+            )
+
+        # Dump the column names to JSON
+        json_columns = strings_as_json(strings=columns)
+
+        # Check if the entry is not in the history
+        if (identifier, json_columns) not in self.history:
+            # Give it the next index
+            self.history[(identifier, json_columns)] = len(self.history)
+
+    def check(self, identifier: Union[str, Identifier], columns: List[str]) -> bool:
+        """
+
+        Args:
+            identifier:
+            columns:
+
+        Returns:
+
+        """
+        if not (isinstance(identifier, str) or isinstance(identifier, Identifier)):
+            raise ValueError(
+                f"Parameter `identifier` should be an instance of class Identifier "
+                f"or str, "
+                f"not {type(identifier)}."
+            )
+
+        # Dump the column names to JSON
+        json_columns = strings_as_json(strings=columns)
+
+        # Check if the entry is already in the history
+        if (identifier, json_columns) in self.history:
+            return True
+        return False
+
+
+class InteractionTapeHierarchyMixin:
+    def __init__(self):
+        self.interactions = {
+            CACHEDOPS: InteractionTape(),
+            SLICEBUILDERS: {
+                SUBPOPULATION: InteractionTape(),
+                TRANSFORMATION: InteractionTape(),
+                ATTACK: InteractionTape(),
+            },
+        }
+
+    def hash_interactions(self):
+        v = 0
+        for path in [
+            [CACHEDOPS],
+            [SLICEBUILDERS, SUBPOPULATION],
+            [SLICEBUILDERS, TRANSFORMATION],
+            [SLICEBUILDERS, ATTACK],
+        ]:
+            v ^= self.fetch_tape(path=path).__hash__()
+        return v
+
+    def dumps_interactions(self):
+        return json.dumps(
+            {
+                CACHEDOPS: self.interactions[CACHEDOPS].dumps(),
+                SLICEBUILDERS: {
+                    SUBPOPULATION: self.interactions[SLICEBUILDERS][
+                        SUBPOPULATION
+                    ].dumps(),
+                    TRANSFORMATION: self.interactions[SLICEBUILDERS][
+                        TRANSFORMATION
+                    ].dumps(),
+                    ATTACK: self.interactions[SLICEBUILDERS][ATTACK].dumps(),
+                },
+            }
+        )
+
+    @classmethod
+    def loads_interactions(cls, s: str) -> InteractionTapeHierarchyMixin:
+        tape_hierarchy = InteractionTapeHierarchyMixin()
+        interactions = json.loads(s)
+        tape_hierarchy.interactions = {
+            CACHEDOPS: InteractionTape.loads(interactions[CACHEDOPS]),
+            SLICEBUILDERS: {
+                SUBPOPULATION: InteractionTape.loads(
+                    interactions[SLICEBUILDERS][SUBPOPULATION]
+                ),
+                TRANSFORMATION: InteractionTape.loads(
+                    interactions[SLICEBUILDERS][TRANSFORMATION]
+                ),
+                ATTACK: InteractionTape.loads(interactions[SLICEBUILDERS][ATTACK]),
+            },
+        }
+        return tape_hierarchy
+
+    def update_tape(
+        self,
+        path: List[str],
+        identifiers: Union[Identifier, List[Identifier]],
+        columns: List[str],
+    ):
+        """Update the tape.
+
+        Args:
+            path: Location of the InteractionTape in the hierarchy.
+            identifiers:
+            columns:
+
+        Returns:
+        """
+        # Fetch the tape
+        tape = self.fetch_tape(path=path)
+
+        # Update it
+        if isinstance(identifiers, Identifier) or isinstance(identifiers, str):
+            return tape.update(identifier=identifiers, columns=columns)
+        else:
+            return [
+                tape.update(identifier=identifier, columns=columns)
+                for identifier in identifiers
+            ]
+
+    def check_tape(
+        self,
+        path: List[str],
+        identifiers: Union[Identifier, List[Identifier]],
+        columns: List[str],
+    ):
+        """Check the tape.
+
+        Args:
+
+            path:
+            identifiers:
+            columns:
+
+        Returns:
+        """
+        # Fetch the tape
+        tape = self.fetch_tape(path=path)
+
+        # Check it
+        if isinstance(identifiers, Identifier) or isinstance(identifiers, str):
+            return tape.check(identifier=identifiers, columns=columns)
+        else:
+            return [
+                tape.check(identifier=identifier, columns=columns)
+                for identifier in identifiers
+            ]
+
+    def fetch_tape(self, path: List[str]) -> InteractionTape:
+        """Fetch an InteractionTape.
+
+        Args:
+            path:
+
+        Returns:
+        """
+        return tz.get_in(path, self.interactions)

--- a/robustnessgym/slicebuilders/attacks/textattack.py
+++ b/robustnessgym/slicebuilders/attacks/textattack.py
@@ -3,9 +3,15 @@ from typing import Dict, List, Tuple
 
 import cytoolz as tz
 import numpy as np
-import textattack.attack_recipes as attack_recipes
-from textattack.attack_recipes import AttackRecipe
-from textattack.models.wrappers import HuggingFaceModelWrapper, ModelWrapper
+
+try:
+    import textattack.attack_recipes as attack_recipes
+    from textattack.attack_recipes import AttackRecipe
+    from textattack.models.wrappers import HuggingFaceModelWrapper, ModelWrapper
+except ImportError:
+    _textattack_available = False
+else:
+    _textattack_available = True
 
 from robustnessgym.core.identifier import Identifier
 from robustnessgym.core.model import Model
@@ -13,10 +19,15 @@ from robustnessgym.slicebuilders.attack import Attack
 
 
 class TextAttack(Attack):
+    """Class for TextAttack."""
+
     def __init__(
         self,
         attack: AttackRecipe,
     ):
+        if not _textattack_available:
+            raise ImportError("Textattack not found. Please `pip install textattack`.")
+
         super(TextAttack, self).__init__(
             identifiers=[
                 Identifier(

--- a/robustnessgym/slicebuilders/slicebuilder.py
+++ b/robustnessgym/slicebuilders/slicebuilder.py
@@ -384,7 +384,6 @@ class SliceBuilder(StorageMixin):
                     for batch in dataset.batch(batch_size)
                 ]
             )
-
             # Update the dataset efficiently by reusing all_batches
             dataset = dataset.map(
                 lambda examples, indices: all_batches[indices[0] // batch_size],

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -48,9 +48,9 @@ class TestDataset(TestCase):
         self.assertEqual(set(dataset.column_names), {"a", "b", "c", "d", "index"})
         self.assertEqual(len(dataset), 9)
 
-    def test_from_json(self):
+    def test_from_jsonl(self):
         # Create a temporary directory
-        os.mkdir("tmp")
+        os.makedirs("tmp", exist_ok=True)
 
         # Create a json file with data
         with jsonlines.open("tmp/data.jsonl", "w") as writer:
@@ -66,7 +66,7 @@ class TestDataset(TestCase):
             )
 
         # Load the dataset
-        dataset = Dataset.from_json(
+        dataset = Dataset.from_jsonl(
             json_path="tmp/data.jsonl",
             identifier=Identifier(_name="MockJSONDataset"),
         )
@@ -79,13 +79,13 @@ class TestDataset(TestCase):
 
     def test_save_load(self):
         # Create a temporary directory
-        os.mkdir("tmp")
+        os.makedirs("tmp", exist_ok=True)
 
         # Save the dataset to disk
-        self.testbed.dataset.save(path="tmp")
+        self.testbed.dataset.save_to_disk(path="tmp")
 
         # Load the dataset from disk
-        dataset = Dataset.load(path="tmp")
+        dataset = Dataset.load_from_disk(path="tmp")
 
         # Remove the temporary directory
         shutil.rmtree("tmp")

--- a/tests/core/test_inmemory_dataset.py
+++ b/tests/core/test_inmemory_dataset.py
@@ -1,0 +1,250 @@
+from unittest import TestCase
+
+from robustnessgym.core.dataformats.inmemory import InMemoryDataset
+
+
+class TestInMemoryDataset(TestCase):
+    def setUp(self):
+        self.batch = {
+            "a": [{"e": 1}, {"e": 2}, {"e": 3}, {"e": 4}],
+            "b": ["u", "v", "w", "x"],
+        }
+        self.dataset = InMemoryDataset.from_batch(self.batch)
+
+    def test_init(self):
+        # Empty dataset
+        dataset = InMemoryDataset()
+        self.assertEqual(len(dataset), 0, "Must be zero length.")
+
+        # Dataset from batch: illegal
+        with self.assertRaises(AssertionError):
+            InMemoryDataset.from_batch(
+                {
+                    "a": [1, 2, 3],
+                    "b": [1, 2, 3, 4],
+                }
+            )
+
+        dataset = InMemoryDataset.from_batch(
+            {
+                "a": [1, 2, 3, 4],
+                "b": ["u", "v", "w", "x"],
+            }
+        )
+        self.assertEqual(len(dataset), 4)
+        self.assertEqual(set(dataset.column_names), {"a", "b"})
+
+        dataset = InMemoryDataset.from_batch(
+            {
+                "a": [{"e": 1}, {"e": 2}, {"e": 3}, {"e": 4}],
+                "b": ["u", "v", "w", "x"],
+            }
+        )
+        self.assertEqual(len(dataset), 4)
+        self.assertEqual(set(dataset.column_names), {"a", "b"})
+
+    def test_getindex(self):
+        self.assertEqual(
+            self.dataset[0],
+            {
+                "a": {"e": 1},
+                "b": "u",
+            },
+        )
+
+        self.assertEqual(
+            self.dataset[1:3],
+            {
+                "a": [{"e": 2}, {"e": 3}],
+                "b": ["v", "w"],
+            },
+        )
+
+        self.assertEqual(
+            self.dataset[:-1],
+            {
+                "a": [{"e": 1}, {"e": 2}, {"e": 3}],
+                "b": ["u", "v", "w"],
+            },
+        )
+
+        self.assertEqual(
+            self.dataset[::-1],
+            {
+                "a": [{"e": 4}, {"e": 3}, {"e": 2}, {"e": 1}],
+                "b": ["x", "w", "v", "u"],
+            },
+        )
+
+    def test_append_1(self):
+        batch = {
+            "a": [1, 2, 3, 4],
+            "b": ["u", "v", "w", "x"],
+        }
+        self.dataset.append(batch)
+
+        self.assertEqual(self.dataset[-1], {"a": 4, "b": "x"})
+        self.assertEqual(len(self.dataset), 8)
+
+    def test_append_2(self):
+        batch = {
+            "a": 1,
+            "b": "u",
+        }
+        self.dataset.append(batch)
+
+        self.assertEqual(self.dataset[-1], {"a": 1, "b": "u"})
+        self.assertEqual(len(self.dataset), 5)
+
+    def test_map_1(self):
+        """Map, with_indices=False, batched=False."""
+        dataset = self.dataset.map(
+            lambda example: {"c": example["a"]},
+            with_indices=False,
+            input_columns=None,
+            batched=False,
+            batch_size=1000,
+            drop_last_batch=False,
+            remove_columns=None,
+            required_columns=None,
+        )
+
+        # Dataset has the right columns
+        self.assertEqual(set(dataset.column_names), {"a", "b", "c"})
+
+        # Original dataset is still the same
+        self.assertEqual(
+            self.dataset[:],
+            self.batch,
+        )
+
+    def test_map_2(self):
+        """Map, with_indices=True, batched=False."""
+        dataset = self.dataset.map(
+            lambda example, index: {"c": example["a"]},
+            with_indices=True,
+            input_columns=None,
+            batched=False,
+            batch_size=1000,
+            drop_last_batch=False,
+            remove_columns=None,
+            required_columns=None,
+        )
+
+        # Dataset has the right columns
+        self.assertEqual(set(dataset.column_names), {"a", "b", "c"})
+
+        # Original dataset is still the same
+        self.assertEqual(
+            self.dataset[:],
+            self.batch,
+        )
+
+    def test_map_3(self):
+        """Map, with_indices=False, batched=True."""
+        dataset = self.dataset.map(
+            lambda example: {"c": example["a"]},
+            with_indices=False,
+            input_columns=None,
+            batched=True,
+            batch_size=1000,
+            drop_last_batch=False,
+            remove_columns=None,
+            required_columns=None,
+        )
+
+        # Dataset has the right columns
+        self.assertEqual(set(dataset.column_names), {"a", "b", "c"})
+
+        # Original dataset is still the same
+        self.assertEqual(
+            self.dataset[:],
+            self.batch,
+        )
+
+    def test_map_4(self):
+        """Map, with_indices=True, batched=True."""
+        dataset = self.dataset.map(
+            lambda example, index: {"c": example["a"]},
+            with_indices=True,
+            input_columns=None,
+            batched=True,
+            batch_size=1000,
+            drop_last_batch=False,
+            remove_columns=None,
+            required_columns=None,
+        )
+
+        # Dataset has the right columns
+        self.assertEqual(set(dataset.column_names), {"a", "b", "c"})
+
+        # Original dataset is still the same
+        self.assertEqual(
+            self.dataset[:],
+            self.batch,
+        )
+
+    def test_map_5(self):
+        """Map, function=None, with_indices=False, batched=False."""
+        dataset = self.dataset.map(
+            None,
+            with_indices=False,
+            batched=False,
+        )
+
+        # Dataset has the right columns
+        self.assertEqual(set(dataset.column_names), {"a", "b"})
+
+        # Original dataset is still the same
+        self.assertEqual(
+            self.dataset[:],
+            self.batch,
+        )
+
+    def test_filter_1(self):
+        dataset = self.dataset.filter(
+            lambda example: example["a"] == {"e": 1},
+            with_indices=False,
+        )
+
+        # Dataset has the right columns
+        self.assertEqual(set(dataset.column_names), {"a", "b"})
+
+        # Dataset has the right data
+        self.assertEqual(
+            dataset[:],
+            {
+                "a": [{"e": 1}],
+                "b": ["u"],
+            },
+        )
+
+        # Original dataset is still the same
+        self.assertEqual(
+            self.dataset[:],
+            self.batch,
+        )
+
+    def test_filter_2(self):
+        dataset = self.dataset.filter(
+            lambda example, index: example["a"] == {"e": 1},
+            with_indices=True,
+        )
+
+        # Dataset has the right columns
+        self.assertEqual(set(dataset.column_names), {"a", "b"})
+
+        # Dataset has the right data
+        self.assertEqual(
+            dataset[:],
+            {
+                "a": [{"e": 1}],
+                "b": ["u"],
+            },
+        )
+
+        # Original dataset is still the same
+        self.assertEqual(
+            self.dataset[:],
+            self.batch,
+        )

--- a/tests/core/test_slice.py
+++ b/tests/core/test_slice.py
@@ -14,7 +14,7 @@ class TestSlice(TestCase):
         sl = Slice.from_dataset(self.testbed.dataset)
         # Compare the slice identifier
         self.assertEqual(
-            str(sl), "Slice[category: curated, num_rows: 6](MockDataset(version=1.0))"
+            str(sl), "RobustnessGymSlice[num_rows: 6](MockDataset(version=1.0))"
         )
         # Length of the slice
         self.assertEqual(len(sl), 6)

--- a/tests/slicebuilders/subpopulations/test_constituency_overlap.py
+++ b/tests/slicebuilders/subpopulations/test_constituency_overlap.py
@@ -22,6 +22,9 @@ class TestConstituencyOverlap(TestCase):
         cos = ConstituencyOverlapSubpopulation(
             intervals=[(0, 20), (20, 40), (40, 60), (60, 80), (80, 100)]
         )
+        print(self.testbed.dataset[:])
+        print(len(self.testbed.dataset), self.testbed.dataset)
+        print(cos.score(self.testbed.dataset[:], columns=["text_a", "text_b"]))
         self.assertTrue(
             np.allclose(
                 cos.score(self.testbed.dataset[:], columns=["text_a", "text_b"]),


### PR DESCRIPTION
Based on feedback related to the speed of using datasets.Dataset for analyzing larger datasets, adds an in-memory dataset class (`InMemoryDataset`) and refactors the `Dataset` class.

Features:
- pure Python `InMemoryDataset` that stores data in a columnar format
- updated tests
- updated `Dataset` class to handle multiple backends
- miscellaneous fixes to integrate the new dataset

Pending:
- further speedups by modifying filter/map implementations + how they're called by other classes