### PR TITLE
Fixed encode/decode issues with Bootleg

### DIFF
--- a/robustnessgym/cachedops/bootleg.py
+++ b/robustnessgym/cachedops/bootleg.py
@@ -59,3 +59,10 @@ class Bootleg(SingleColumnCachedOperation):
         ]
 
         return list_bootleg_results
+
+    def encode(cls, obj) -> str:
+        """Custom encode to allow for np.ndarray to be passed"""
+        return obj
+
+    def decode(cls, s: str):
+        return s


### PR DESCRIPTION
Errors with encode/decode np.ndarrays in Bootleg. Modified the encoder/decoder to be identity.