### PR TITLE
Make Dataset identifier parameter "version" str

### DIFF
--- a/robustnessgym/core/dataset.py
+++ b/robustnessgym/core/dataset.py
@@ -222,7 +222,7 @@ class Dataset(
 
         # Check for split, version information
         split = str(self._dataset.split) if self._dataset.split else None
-        version = self._dataset.version if self._dataset.version else None
+        version = str(self._dataset.version) if self._dataset.version else None
 
         # Add all available information to kwargs dict
         kwargs = {}

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -177,3 +177,4 @@ class TestDataset(TestCase):
         # Check that we got 20 examples
         self.assertTrue(isinstance(dataset, Dataset))
         self.assertEqual(len(dataset), 20)
+        self.assertTrue(isinstance(dataset.identifier.parameters["version"], str))


### PR DESCRIPTION
Dataset version from `datasets` throwing errors due to lack of JSON serializability. Converts version to str in the identifier.