### PR TITLE
Implement `to_dataloader` for VisionDataset and replaced VisionFolder…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,10 @@ Set up a development environment with `poetry` by running the following command 
    $ pip install poetry
    $ poetry install
    ```
-
+Note: in order to pass the full test suite (step 5), you'll need to install all extra in addition. 
+```bash
+   $ poetry install --extras "adversarial augmentation summarization text vision"
+```
 5. Develop features on your branch.
 
    As you work on the features, you should make sure that the test suite

--- a/tests/core/test_vision_dataset.py
+++ b/tests/core/test_vision_dataset.py
@@ -29,6 +29,26 @@ class TestVisionDataset(TestCase):
         }
         self.dataset = VisionDataset(self.batch, img_keys="i")
 
+    def test_to_dataloader(self):
+        # test that correct objects are returned by dataloader
+        for i, b in self.dataset.to_dataloader(keys=["i", "b"]):
+            self.assertEqual(b[0], "u")
+            self.assertTrue(torch.equal(i.squeeze(), self.images[0].load()))
+            break
+
+        # test that you can pass dataloader kwargs
+        imgs = [img for img in self.dataset.to_dataloader(keys=["i"], batch_size=2)]
+        self.assertEqual(len(imgs), 2)
+
+    def test_to_dataloader_transforms(self):
+        imgs = [
+            img
+            for img, _ in self.dataset.to_dataloader(
+                keys=["i", "b"], key_to_transform={"i": lambda x: torch.zeros_like(x)}
+            )
+        ]
+        self.assertTrue(torch.all(torch.eq(imgs[0], 0)))
+
     def test_init(self):
         # Empty dataset
         dataset = VisionDataset()


### PR DESCRIPTION
… with TorchDataset.

In workflows that involve training or evaluation loops outside of RG, it's useful if an RG dataset1 can spit out a dataloader, without asking the user to define a torch dataset. For example:
```
        dataset = Dataset(...)
        for img, target in dataset.to_dataloader(
            keys=["img_path", "label"],
            batch_size=16,
            num_workers=12
        ):
            out = model(img)
            loss = loss(out, target)
            ...
```
This functionality is now implemented for Dataset with `_dataset_fmt=="vision"`.
If we want this functionality, for other formats, it will need to be implemented. Currently,
a `NotImplementedError` is raised.
Other changes:
- Noted need to install extras for pytest in CONTRIBUTING.md
- Optional dependencies `torchvision` and `PIL` are now imported lazily, instead of being set to `None`
- `num_procs` is passed onto `map` in `filter`