### PR TITLE
Prerelease: 0.0.4-alpha.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "robustnessgym"
-version = "0.0.4-alpha.0"
+version = "v0.0.4-alpha.1"
 description = "Robustness Gym is an evaluation toolkit for natural language processing."
 authors = ["Robustness Gym <kgoel@cs.stanford.edu>"]
 maintainers = ["Karan Goel <kgoel@cs.stanford.edu>"]


### PR DESCRIPTION
- adds `mandoline` for computing metrics on unlabeled data
- fixes issues with tasks and schemas across `TestBench` evaluation
- adds `to_dataloader` to `VisionDataset` and replaces `VisionFolder` with `TorchDataset`