### PR TITLE
Add `ActivationCachedOp` and introduce `RGImageRow` and `RGImageCol`

### DIFF
--- a/robustnessgym/cachedops/activation.py
+++ b/robustnessgym/cachedops/activation.py
@@ -1,0 +1,101 @@
+from functools import reduce
+from typing import Dict, List
+
+import torch
+import torch.nn as nn
+
+from robustnessgym import Dataset
+from robustnessgym.core.cachedops import SingleColumnCachedOperation
+from robustnessgym.core.decorators import singlecolumn
+
+
+class ActivationExtractor:
+    """Class for extracting activations of a targetted intermediate layer."""
+
+    def __init__(self):
+        self.activation = None
+
+    def add_hook(self, module, input, output):
+        self.activation = output
+
+
+class ActivationCachedOp(SingleColumnCachedOperation):
+    def __init__(self, model: nn.Module, target_module: str, device: int = None):
+        """ A cached operation that runs a forward pass over 
+        each example in the dataset and stores model activations in a new column. 
+        TODO: test on an NLP model 
+
+        Args:
+            model (nn.Module): the torch model from which activations are extracted
+            target_module (str): the name of the submodule of `model` (i.e. an
+                intermediate layer) that outputs the activations we'd like to extract.
+                For nested submodules, specify a path separated by "." (e.g.
+                `ActivationCachedOp(model, "block4.conv")`).
+            device (int, optional): the device for the forward pass. Defaults to None,
+                in which case the CPU is used.
+        """
+        self.model = model
+        self.device = device
+
+        try:
+            target_module = _nested_getattr(model, target_module)
+        except nn.modules.module.ModuleAttributeError:
+            raise ValueError(f"model does not have a submodule {target_module}")
+
+        self.extractor = ActivationExtractor()
+        target_module.register_forward_hook(self.extractor.add_hook)
+
+        super(ActivationCachedOp, self).__init__()
+
+    # TODO(sabri): make a proper encoder/decoder pair using torch.save
+    @classmethod
+    def encode(cls, obj: torch.Tensor) -> torch.Tensor:
+        return obj
+
+    @classmethod
+    def decode(cls, obj: torch.Tensor) -> torch.Tensor:
+        return obj
+
+    def prepare_dataset(
+        self,
+        dataset: Dataset,
+        columns: List[str],
+        batch_size: int = 32,
+        *args,
+        **kwargs,
+    ) -> None:
+
+        # First reset the scores
+        if self.device is not None:
+            self.model.to(self.device)
+
+        # Prepare the dataset
+        super(ActivationCachedOp, self).prepare_dataset(
+            dataset=dataset,
+            columns=columns,
+            batch_size=batch_size,
+            *args,
+            **kwargs,
+        )
+
+    @singlecolumn
+    def apply(self, batch: Dict[str, List], columns: List[str], **kwargs) -> List:
+        inputs = batch[columns[0]]
+
+        if self.device is not None:
+            inputs = inputs.to(self.device)
+
+        self.model(inputs)
+        return self.extractor.activation.cpu().detach()
+
+
+def _nested_getattr(obj, attr, *args):
+    """Get a nested property from an object.
+
+    Example:
+    ```
+        model = ...
+        weights = _nested_getattr(model, "layer4.weights")
+    ```
+    """
+    return reduce(lambda o, a: getattr(o, a, *args), [obj] + attr.split("."))

--- a/robustnessgym/core/dataset.py
+++ b/robustnessgym/core/dataset.py
@@ -462,17 +462,17 @@ class Dataset(
 
     def to_dataloader(
         self,
-        keys: Sequence[str],
-        key_to_transform: Optional[Mapping[str, Callable]] = None,
+        columns: Sequence[str],
+        column_to_transform: Optional[Mapping[str, Callable]] = None,
         **kwargs,
     ) -> torch.utils.data.DataLoader:
         """Get a PyTorch dataloader that iterates over a subset of the columns
-        (specified by `keys`) in the dataset. This is handy when using the dataset with
-        training or evaluation loops outside of robustnessgym.  For example:
+        (specified by `columns`) in the dataset. This is handy when using the dataset
+        with training or evaluation loops outside of robustnessgym.  For example:
         ```
         dataset = Dataset(...)
         for img, target in dataset.to_dataloader(
-            keys=["img_path", "label"],
+            columns=["img_path", "label"],
             batch_size=16,
             num_workers=12
         ):
@@ -482,13 +482,13 @@ class Dataset(
         ```
 
         Args:
-            keys (Sequence[str]): A subset of the columns in the dataset.
+            columns (Sequence[str]): A subset of the columns in the dataset.
                 Specifies the columns to load. The dataloader will return values in same
-                 order as `keys` here.
-            key_to_transform (Optional[Mapping[str, Callable]], optional): A mapping
-                from zero or more `keys` to callable transforms to be applied by the
+                 order as `columns` here.
+            column_to_transform (Optional[Mapping[str, Callable]], optional): A mapping
+                from zero or more `columns` to callable transforms to be applied by the
                 dataloader. Defaults to None, in which case no transforms are applied.
-                Example: `key_to_transform={"img_path": transforms.Resize((128,128))}`.
+                e.g. `column_to_transform={"img_path": transforms.Resize((128,128))}`.
 
         Returns:
             torch.utils.data.DataLoader: dataloader that iterates over dataset
@@ -498,7 +498,7 @@ class Dataset(
                 f'`to_dataloader` is not supported for format "{self._dataset_fmt}"'
             )
         return self._dataset.to_dataloader(
-            keys=keys, key_to_transform=key_to_transform, **kwargs
+            columns=columns, column_to_transform=column_to_transform, **kwargs
         )
 
     def to_jsonl(self, path: str) -> None:

--- a/tests/cached_ops/test_activation.py
+++ b/tests/cached_ops/test_activation.py
@@ -1,0 +1,40 @@
+from unittest import TestCase
+
+import torch
+import torch.nn as nn
+
+from robustnessgym.cachedops.activation import ActivationCachedOp
+from tests.testbeds import MockVisionTestBed
+
+
+class TestModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.hidden = nn.Conv2d(
+            in_channels=3, out_channels=2, kernel_size=1, bias=False
+        )
+        self.hidden.weight.data[:] = torch.zeros_like(self.hidden.weight.data)
+
+    def forward(self, x):
+        x = x.permute(0, -1, 1, 2).to(torch.float)
+        x = self.hidden(x)
+        return x
+
+
+class TestActivation(TestCase):
+    def setUp(self):
+        self.model = TestModel()
+        self.dataset = MockVisionTestBed(wrap_dataset=True).dataset
+
+    def test_apply(self):
+        cached_op = ActivationCachedOp(model=self.model, target_module="hidden")
+
+        dataset = cached_op(self.dataset, columns=["i"])
+
+        # Make sure things match up
+        acts = cached_op.retrieve(dataset[:], ["i"])
+        self.assertEqual(type(acts), list)
+
+        acts = torch.stack(acts)
+        self.assertTrue(torch.all(torch.eq(acts, 0)))
+        self.assertEqual(list(acts.shape), [4, 2, 10, 10])

--- a/tests/core/test_vision_dataset.py
+++ b/tests/core/test_vision_dataset.py
@@ -1,50 +1,33 @@
-import os
-import tempfile
 from unittest import TestCase
 
 import torch
 
-from robustnessgym.core.dataformats.vision import RGImage, VisionDataset, save_image
+from robustnessgym.core.dataformats.vision import VisionDataset
+from tests.testbeds import MockVisionTestBed
 
 
 class TestVisionDataset(TestCase):
     def setUp(self):
-        # Create some test images
-        cache_dir = os.path.join(tempfile.gettempdir(), "RGVisionTests")
-        if not os.path.exists(cache_dir):
-            os.makedirs(cache_dir)
-        self.image_paths = []
-        self.image_tensors = []
-        self.images = []
-        for i in range(200, 231, 10):
-            self.image_paths.append(os.path.join(cache_dir, "{}.png".format(i)))
-            self.image_tensors.append(i * torch.ones((10, 10, 3)))
-            save_image(self.image_tensors[-1], self.image_paths[-1])
-            self.images.append(RGImage(self.image_paths[-1]))
-
-        self.batch = {
-            "a": [{"e": 1}, {"e": 2}, {"e": 3}, {"e": 4}],
-            "b": ["u", "v", "w", "x"],
-            "i": self.image_paths,
-        }
-        self.dataset = VisionDataset(self.batch, img_keys="i")
+        self.testbed = MockVisionTestBed()
+        self.dataset = self.testbed.dataset
 
     def test_to_dataloader(self):
         # test that correct objects are returned by dataloader
-        for i, b in self.dataset.to_dataloader(keys=["i", "b"]):
+        for i, b in self.dataset.to_dataloader(columns=["i", "b"]):
             self.assertEqual(b[0], "u")
-            self.assertTrue(torch.equal(i.squeeze(), self.images[0].load()))
+            self.assertTrue(torch.equal(i.squeeze(), self.testbed.images[0].load()))
             break
 
         # test that you can pass dataloader kwargs
-        imgs = [img for img in self.dataset.to_dataloader(keys=["i"], batch_size=2)]
+        imgs = [img for img in self.dataset.to_dataloader(columns=["i"], batch_size=2)]
         self.assertEqual(len(imgs), 2)
 
     def test_to_dataloader_transforms(self):
         imgs = [
             img
             for img, _ in self.dataset.to_dataloader(
-                keys=["i", "b"], key_to_transform={"i": lambda x: torch.zeros_like(x)}
+                columns=["i", "b"],
+                column_to_transform={"i": lambda x: torch.zeros_like(x)},
             )
         ]
         self.assertTrue(torch.all(torch.eq(imgs[0], 0)))
@@ -57,12 +40,17 @@ class TestVisionDataset(TestCase):
         # Dataset from batch: illegal
         with self.assertRaises(AssertionError):
             VisionDataset(
-                {"a": [1, 2, 3], "b": [1, 2, 3, 4], "i": self.image_paths}, img_keys="i"
+                {"a": [1, 2, 3], "b": [1, 2, 3, 4], "i": self.testbed.image_paths},
+                img_columns="i",
             )
 
         dataset = VisionDataset(
-            {"a": [1, 2, 3, 4], "b": ["u", "v", "w", "x"], "i": self.image_paths},
-            img_keys="i",
+            {
+                "a": [1, 2, 3, 4],
+                "b": ["u", "v", "w", "x"],
+                "i": self.testbed.image_paths,
+            },
+            img_columns="i",
         )
         self.assertEqual(len(dataset), 4)
         self.assertEqual(set(dataset.column_names), {"a", "b", "i"})
@@ -71,9 +59,9 @@ class TestVisionDataset(TestCase):
             {
                 "a": [{"e": 1}, {"e": 2}, {"e": 3}, {"e": 4}],
                 "b": ["u", "v", "w", "x"],
-                "i": self.image_paths,
+                "i": self.testbed.image_paths,
             },
-            img_keys="i",
+            img_columns="i",
         )
         self.assertEqual(len(dataset), 4)
         self.assertEqual(set(dataset.column_names), {"a", "b", "i"})
@@ -81,12 +69,12 @@ class TestVisionDataset(TestCase):
     def test_getindex(self):
         self.assertEqual(
             self.dataset[0],
-            {"a": {"e": 1}, "b": "u", "i": self.images[0]},
+            {"a": {"e": 1}, "b": "u", "i": self.testbed.images[0]},
         )
 
         self.assertEqual(
             self.dataset[1:3],
-            {"a": [{"e": 2}, {"e": 3}], "b": ["v", "w"], "i": self.images[1:3]},
+            {"a": [{"e": 2}, {"e": 3}], "b": ["v", "w"], "i": self.testbed.images[1:3]},
         )
 
         self.assertEqual(
@@ -94,7 +82,7 @@ class TestVisionDataset(TestCase):
             {
                 "a": [{"e": 1}, {"e": 2}, {"e": 3}],
                 "b": ["u", "v", "w"],
-                "i": self.images[:-1],
+                "i": self.testbed.images[:-1],
             },
         )
 
@@ -103,7 +91,7 @@ class TestVisionDataset(TestCase):
             {
                 "a": [{"e": 4}, {"e": 3}, {"e": 2}, {"e": 1}],
                 "b": ["x", "w", "v", "u"],
-                "i": self.images[::-1],
+                "i": self.testbed.images[::-1],
             },
         )
 
@@ -111,18 +99,22 @@ class TestVisionDataset(TestCase):
         batch = {
             "a": [1, 2, 3, 4],
             "b": ["u", "v", "w", "x"],
-            "i": self.image_paths[::-1],
+            "i": self.testbed.image_paths[::-1],
         }
         self.dataset.append(batch)
 
-        self.assertEqual(self.dataset[-1], {"a": 4, "b": "x", "i": self.images[0]})
+        self.assertEqual(
+            self.dataset[-1], {"a": 4, "b": "x", "i": self.testbed.images[0]}
+        )
         self.assertEqual(len(self.dataset), 8)
 
     def test_append_2(self):
-        batch = {"a": 1, "b": "u", "i": self.image_paths[0]}
+        batch = {"a": 1, "b": "u", "i": self.testbed.image_paths[0]}
         self.dataset.append(batch)
 
-        self.assertEqual(self.dataset[-1], {"a": 1, "b": "u", "i": self.images[0]})
+        self.assertEqual(
+            self.dataset[-1], {"a": 1, "b": "u", "i": self.testbed.images[0]}
+        )
         self.assertEqual(len(self.dataset), 5)
 
     def test_map_1(self):
@@ -137,13 +129,13 @@ class TestVisionDataset(TestCase):
         )
 
         # Original dataset is still the same
-        self.assertEqual(self.dataset[:], self.batch)
+        self.assertEqual(self.dataset[:], self.testbed.batch)
 
         # Output is correct
         self.assertEqual(output["c"], self.dataset["a"])
 
         for i, img in enumerate(output["k"]):
-            self.assertTrue(torch.equal(1.0 * img, self.image_tensors[i]))
+            self.assertTrue(torch.equal(1.0 * img, self.testbed.image_tensors[i]))
 
     def test_map_2(self):
         """Map, with_indices=True, batched=False."""
@@ -157,13 +149,13 @@ class TestVisionDataset(TestCase):
         )
 
         # Original dataset is still the same
-        self.assertEqual(self.dataset[:], self.batch)
+        self.assertEqual(self.dataset[:], self.testbed.batch)
 
         # Output is correct
         self.assertEqual(output["c"], self.dataset["a"])
 
         for i, img in enumerate(output["k"]):
-            self.assertTrue(torch.equal(1.0 * img, self.image_tensors[i]))
+            self.assertTrue(torch.equal(1.0 * img, self.testbed.image_tensors[i]))
 
     def test_map_3(self):
         """Map, with_indices=False, batched=True."""
@@ -177,13 +169,13 @@ class TestVisionDataset(TestCase):
         )
 
         # Original dataset is still the same
-        self.assertEqual(self.dataset[:], self.batch)
+        self.assertEqual(self.dataset[:], self.testbed.batch)
 
         # Output is correct
         self.assertEqual(output["c"], self.dataset["a"])
 
         for i, img in enumerate(output["k"]):
-            self.assertTrue(torch.equal(1.0 * img, self.image_tensors[i]))
+            self.assertTrue(torch.equal(1.0 * img, self.testbed.image_tensors[i]))
 
     def test_map_4(self):
         """Map, with_indices=True, batched=True."""
@@ -197,13 +189,13 @@ class TestVisionDataset(TestCase):
         )
 
         # Original dataset is still the same
-        self.assertEqual(self.dataset[:], self.batch)
+        self.assertEqual(self.dataset[:], self.testbed.batch)
 
         # Output is correct
         self.assertEqual(output["c"], self.dataset["a"])
 
         for i, img in enumerate(output["k"]):
-            self.assertTrue(torch.equal(1.0 * img, self.image_tensors[i]))
+            self.assertTrue(torch.equal(1.0 * img, self.testbed.image_tensors[i]))
 
     def test_map_5(self):
         """Map, function=None, with_indices=False, batched=False."""
@@ -216,7 +208,7 @@ class TestVisionDataset(TestCase):
         # Original dataset is still the same
         self.assertEqual(
             self.dataset[:],
-            self.batch,
+            self.testbed.batch,
         )
 
         # Output is None
@@ -225,7 +217,7 @@ class TestVisionDataset(TestCase):
     def test_filter_1(self):
         dataset = self.dataset.filter(
             lambda example: example["a"] == {"e": 1}
-            and torch.equal(1.0 * example["i"], self.image_tensors[0]),
+            and torch.equal(1.0 * example["i"], self.testbed.image_tensors[0]),
             with_indices=False,
         )
 
@@ -243,18 +235,18 @@ class TestVisionDataset(TestCase):
             ["u"],
         )
 
-        self.assertEqual(dataset["i"], [self.images[0]])
+        self.assertEqual(dataset["i"], [self.testbed.images[0]])
 
         # Original dataset is still the same
         self.assertEqual(
             self.dataset[:],
-            self.batch,
+            self.testbed.batch,
         )
 
     def test_filter_2(self):
         dataset = self.dataset.filter(
             lambda example, index: example["a"] == {"e": 1}
-            and torch.equal(1.0 * example["i"], self.image_tensors[0]),
+            and torch.equal(1.0 * example["i"], self.testbed.image_tensors[0]),
             with_indices=True,
         )
 
@@ -272,12 +264,12 @@ class TestVisionDataset(TestCase):
             ["u"],
         )
 
-        self.assertEqual(dataset["i"], [self.images[0]])
+        self.assertEqual(dataset["i"], [self.testbed.images[0]])
 
         # Original dataset is still the same
         self.assertEqual(
             self.dataset[:],
-            self.batch,
+            self.testbed.batch,
         )
 
     def test_filter_3(self):
@@ -298,18 +290,18 @@ class TestVisionDataset(TestCase):
         # Datasets have the right data
         self.assertEqual(
             dataset_1[:],
-            {"a": [{"e": 3}, {"e": 4}], "b": ["w", "x"], "i": self.images[2:]},
+            {"a": [{"e": 3}, {"e": 4}], "b": ["w", "x"], "i": self.testbed.images[2:]},
         )
 
         self.assertEqual(
             dataset_2[:],
-            {"a": [{"e": 4}], "b": ["x"], "i": self.images[3:]},
+            {"a": [{"e": 4}], "b": ["x"], "i": self.testbed.images[3:]},
         )
 
         # Original dataset is still the same
         self.assertEqual(
             self.dataset[:],
-            self.batch,
+            self.testbed.batch,
         )
 
     def test_filter_add_column(self):
@@ -324,7 +316,7 @@ class TestVisionDataset(TestCase):
         # Dataset has the right data
         self.assertEqual(
             dataset[:],
-            {"a": [{"e": 1}], "b": ["u"], "c": ["u"], "i": [self.images[0]]},
+            {"a": [{"e": 1}], "b": ["u"], "c": ["u"], "i": [self.testbed.images[0]]},
         )
 
     def test_remove_column(self):


### PR DESCRIPTION
Some slice discovery methods operate on the intermediate activations of
a trained model (GEORGE and Blind Source Separation are examples). Since
we expect several discovery methods to rely on this functionaly, we implement
a cached operation called `ActivationCachedOp` that runs a forward pass over
each example in the dataset and stores model activations in a new column. Note
this has only be tested on `VisionDataset`.

A number of changes were made to `VisionDataset` to support `ActivationCachedOp`
and future `update` and `map` based operations over vision datasets. Most notably,
`VisionDataset.__getitem__(index)` now returns instances of `RGImageRow` and
`RGImageBatch` instead of vanilla dictionaries.To the end user, these instances
should be largely indistinguishable from a batch represented by dictionary (like
those returned by`InMemoryDataset`) with the main difference being being that image
columns are loaded lazily and collated (i.e. stacked) into one tensor only when
those columns are accessed. Why do we need this? We want batches returned
by `dataset[:batch_size]` to be compatible with functions designed for `update` or
`map`. A function designed for `update` or `map` should expect a batch with
the images already loaded, since the dataloader in `map` will have already loaded
them. Previously, if we wanted to use that same function with a one-off batch (e.g.
`fn(dataset[:batch_size])`) we would first need to call `load` on each of the
images. This is a problem because (1) this assumes the user knows how to collate
the examples into a batch in a way that is consistent with the dataloader in
the dataset and (2) it requires some hacky overrides of some inherited
methods that assume `fn(dataset[:batch_size])` works (e.g. _inspect_function).
With `RGImageRow` and `RGImageBatch` is guaranteed to `fn(dataset[:batch_size])`
results consistent with what we'd get from `map(fn)`.

Additionally, one can now specify image transforms in `VisionDataset`. These are
stored in the `RGImage` instances and applied on `load.`

Other changes:
- `img_keys` are now referred to as `img_columns` throughout vision.py
- the creation of a test `VisionDataset` has been moved to `tests.testbeds`
so it can be shared with other testing modules