### PR TITLE
Update TestBench for API

### DIFF
--- a/robustnessgym/core/testbench.py
+++ b/robustnessgym/core/testbench.py
@@ -1026,6 +1026,9 @@ class TestBench(SemanticVersionerMixin):
                 "task": self.task,
                 "identifier": self.identifier,
                 "dataset_id": self.dataset_id,
+                "slices": [
+                    (sl.identifier, sl.category, sl.lineage) for sl in self.slices
+                ],
             },
             open(str(savedir / "metadata.dill"), "wb"),
         )
@@ -1058,6 +1061,24 @@ class TestBench(SemanticVersionerMixin):
                 testbench_identifiers.append(maybe_testbench.name)
 
         return testbench_identifiers
+
+    @classmethod
+    def load_metrics(cls, path: str) -> dict:
+        """Load metrics from disk."""
+        # Path to the save directory
+        savedir = pathlib.Path(path)
+
+        # Load metrics
+        return dill.load(open(str(savedir / "metrics.dill"), "rb"))
+
+    @classmethod
+    def load_metadata(cls, path: str) -> dict:
+        """Load metrics from disk."""
+        # Path to the save directory
+        savedir = pathlib.Path(path)
+
+        # Load metrics
+        return dill.load(open(str(savedir / "metadata.dill"), "rb"))
 
     @classmethod
     def load(cls, path: str) -> TestBench:

--- a/robustnessgym/core/testbench.py
+++ b/robustnessgym/core/testbench.py
@@ -1027,7 +1027,8 @@ class TestBench(SemanticVersionerMixin):
                 "identifier": self.identifier,
                 "dataset_id": self.dataset_id,
                 "slices": [
-                    (sl.identifier, sl.category, sl.lineage) for sl in self.slices
+                    (sl.identifier, sl.category, sl.lineage, len(sl))
+                    for sl in self.slices
                 ],
             },
             open(str(savedir / "metadata.dill"), "wb"),


### PR DESCRIPTION
Updates `TestBench` to add support for
- partial loading of metadata and metrics from disk
- dumping slice information to metadata (identifier, category, lineage, length)