### PR TITLE
Unify map of `AbstractColumn` and `DataPane` into `MappableMixin`

### DIFF
--- a/robustnessgym/mosaic/__init__.py
+++ b/robustnessgym/mosaic/__init__.py
@@ -4,6 +4,10 @@ Imports for robustnessgym.mosaic
 # flake8: noqa
 from .cells.imagepath import ImagePath
 from .cells.spacy import LazySpacyCell, SpacyCell
-from .columns.list_column import ListColumn
+from .cells.abstract import AbstractCell
+from .columns.cell_column import CellColumn
+from .columns.spacy_column import SpacyColumn
+from .columns.abstract import AbstractColumn
 from .columns.numpy_column import NumpyArrayColumn
+from .columns.list_column import ListColumn
 from .datapane import DataPane

--- a/robustnessgym/mosaic/mixins/inspect_fn.py
+++ b/robustnessgym/mosaic/mixins/inspect_fn.py
@@ -86,18 +86,19 @@ class FunctionInspectorMixin:
             ):
                 # `function` returns a bool per example
                 bool_output = True
+        
+        if not isinstance(output, Mapping):
+            # Record the shape of the output
+            if hasattr(output, "shape"):
+                output_shape = output.shape
+            elif len(output) > 0 and hasattr(output[0], "shape"):
+                output_shape = output[0].shape
 
-        # Record the shape of the output
-        if hasattr(output, "shape"):
-            output_shape = output.shape
-        elif hasattr(output[0], "shape"):
-            output_shape = output[0].shape
-
-        # Record the dtype of the output
-        if hasattr(output, "dtype"):
-            output_dtype = output.dtype
-        elif hasattr(output[0], "dtype"):
-            output_dtype = output[0].dtype
+            # Record the dtype of the output
+            if hasattr(output, "dtype"):
+                output_dtype = output.dtype
+            elif len(output) > 0 and hasattr(output[0], "dtype"):
+                output_dtype = output[0].dtype
 
         return SimpleNamespace(
             output=output,

--- a/robustnessgym/mosaic/mixins/mapping.py
+++ b/robustnessgym/mosaic/mixins/mapping.py
@@ -1,0 +1,155 @@
+from typing import Callable, Mapping, Optional, Union
+import logging
+from tqdm.auto import tqdm
+from robustnessgym.core.tools import convert_to_batch_column_fn, recmerge
+
+
+logger = logging.getLogger(__name__)
+
+
+class MappableMixin:
+    def __init__(self, *args, **kwargs):
+        super(MappableMixin, self).__init__(*args, **kwargs)
+
+    def map(
+        self,
+        function: Optional[Callable] = None,
+        with_indices: bool = False,
+        batched: bool = False,
+        batch_size: Optional[int] = 1000,
+        drop_last_batch: bool = False,
+        num_workers: Optional[int] = None,
+        output_type: type = None,
+        mmap: bool = False,
+        **kwargs,
+    ):
+        # TODO (sabri): add materialize?
+        from robustnessgym.mosaic.columns.abstract import AbstractColumn
+        from robustnessgym.mosaic import DataPane
+
+        """Map a function over the elements of the column."""
+        # Check if need to materialize:
+        # TODO(karan): figure out if we need materialize=False
+
+        # Just return if the function is None
+        if function is None:
+            logger.info("`function` None, returning None.")
+            return None
+
+        # Ensure that num_workers is not None
+        if num_workers is None:
+            num_workers = 0
+
+        # Return if `self` has no examples
+        if not len(self):
+            logger.info("Dataset empty, returning None.")
+            return None
+
+        if not batched:
+            # Convert to a batch function
+            function = self._convert_to_batch_fn(function, with_indices=with_indices)
+            batched = True
+            logger.info(f"Converting `function` {function} to a batched function.")
+
+        # Run the map
+        logger.info("Running `map`, the dataset will be left unchanged.")
+        for i, batch in tqdm(
+            enumerate(
+                self.batch(
+                    batch_size=batch_size,
+                    drop_last_batch=drop_last_batch,
+                    num_workers=num_workers
+                    # TODO: collate=batched was commented out in list_column
+                )
+            ),
+            total=(len(self) // batch_size)
+            + int(not drop_last_batch and len(self) % batch_size != 0),
+        ):
+            # Calculate the start and end indexes for the batch
+            start_index = i * batch_size
+            end_index = min(len(self), (i + 1) * batch_size)
+
+            # Use the first batch for setup
+            if i == 0:
+                # Get some information about the function
+                function_properties = self._inspect_function(
+                    function,
+                    with_indices,
+                    batched,
+                    batch,
+                    range(start_index, end_index),
+                )
+
+                # Pull out information
+                output = function_properties.output
+                dtype = function_properties.output_dtype
+                is_mapping = isinstance(output, Mapping)
+                writers, output_types = {}, {}
+                for key, curr_output in output.items() if is_mapping else [(0, output)]:
+                    curr_output_type = (
+                        type(AbstractColumn.from_data(curr_output))
+                        if output_type is None
+                        else output_type
+                    )
+                    output_types[key] = curr_output_type
+                    writer = curr_output_type.get_writer(mmap=mmap)
+
+                    # Setup for writing to a certain output column
+                    # TODO: support optionally memmapping only some columns
+                    if mmap:
+                        shape = (len(self), *curr_output.shape)
+                        # Construct the mmap file path
+                        # TODO: how/where to store the files
+                        path = self.logdir / f"{hash(function)}" / key
+                        # Open the output writer
+                        writer.open(str(path), dtype, shape=shape)
+                    else:
+                        # Create an empty dict or list for the outputs
+                        writer.open()
+                    writers[key] = writer
+
+            else:
+                # Run `function` on the batch
+                output = (
+                    function(
+                        batch,
+                        range(i * batch_size, min(len(self), (i + 1) * batch_size)),
+                    )
+                    if with_indices
+                    else function(batch)
+                )
+
+            # Append the output
+            if output is not None:
+                if isinstance(output, Mapping):
+                    if set(output.keys()) != set(writers.keys()):
+                        raise ValueError(
+                            "Map function must return same keys for each batch."
+                        )
+                    for k, writer in writers.items():
+                        writer.write(output[k])
+                else:
+                    writers[0].write(output)
+
+        # Check if we are returning a special output type
+        outputs = {}
+        for key, writer in writers.items():
+            if mmap:
+                writer.flush()
+                # TODO: Writers should have correspondence to their own columns
+                outputs[key] = output_types[key].read(
+                    str(path),
+                    mmap=mmap,
+                    dtype=dtype,
+                    shape=shape,
+                )
+            else:
+                data = writer.flush()
+                outputs[key] = output_types[key].from_data(data)
+
+        if not is_mapping:
+            outputs = outputs[0]
+        else:
+            outputs = DataPane.from_batch(outputs)
+
+        return outputs

--- a/robustnessgym/mosaic/writers/list_writer.py
+++ b/robustnessgym/mosaic/writers/list_writer.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+
+import numpy as np
+
+from robustnessgym.mosaic.writers.abstract import AbstractWriter
+
+
+class ListWriter(AbstractWriter):
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        super(ListWriter, self).__init__(*args, **kwargs)
+
+    def open(self) -> None:
+        self.outputs = []
+    
+    def write(self, data, **kwargs) -> None:
+        self.outputs.extend(data)
+
+    def flush(self, *args, **kwargs):
+        return self.outputs
+
+    def close(self, *args, **kwargs):
+        pass

--- a/robustnessgym/mosaic/writers/numpy_writer.py
+++ b/robustnessgym/mosaic/writers/numpy_writer.py
@@ -53,3 +53,25 @@ class NumpyMemmapWriter(AbstractWriter):
 
     def close(self, *args, **kwargs):
         pass
+
+
+class NumpyWriter(AbstractWriter):
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        super(NumpyWriter, self).__init__(*args, **kwargs)
+
+    def open(self) -> None:
+        self.outputs = []
+    
+    def write(self, data, **kwargs) -> None:
+        self.outputs.extend(data)
+
+    def flush(self, *args, **kwargs):
+        return np.asarray(self.outputs)
+
+    def close(self, *args, **kwargs):
+        pass
+

--- a/tests/mosaic/columns/test_numpy_column.py
+++ b/tests/mosaic/columns/test_numpy_column.py
@@ -1,0 +1,59 @@
+"""Unittests for Datasets."""
+import os
+import shutil
+from unittest import TestCase
+
+import numpy as np
+import torch
+
+from robustnessgym.mosaic.datapane import DataPane
+from robustnessgym.mosaic import NumpyArrayColumn
+
+
+class TestNumpyColumn(TestCase):
+    def setUp(self):
+        # Arrange
+        pass
+
+    def test_from_array(self):
+        # Build a dataset from a batch
+        array = np.random.rand(10, 3, 3)
+        col = NumpyArrayColumn.from_array(
+            array
+        )
+
+        self.assertTrue((col == array).all())
+        self.assertEqual(len(col), 10)
+    
+    def test_mixed_batched_map_return_single(self):
+        array = np.random.rand(16, 3)
+        col = NumpyArrayColumn.from_array(array)
+
+        def func(x):
+            out = x.mean(axis=-1)
+            return out
+
+        result = col.map(func, batch_size=4, batched=True)
+        self.assertTrue(isinstance(result, NumpyArrayColumn))
+        self.assertEqual(len(result), 16)
+        self.assertTrue((result == array.mean(axis=-1)).all())
+    
+    def test_mixed_batched_map_return_multiple(self):
+        array = np.random.rand(16, 3)
+        col = NumpyArrayColumn.from_array(array)
+
+        def func(x):
+            return {
+                "mean": x.mean(axis=-1),
+                "std": x.std(axis=-1)
+            }
+
+        result = col.map(func, batch_size=4, batched=True)
+        self.assertTrue(isinstance(result, DataPane))
+        self.assertTrue(isinstance(result["std"], NumpyArrayColumn))
+        self.assertTrue(isinstance(result["mean"], NumpyArrayColumn))
+        self.assertEqual(len(result), 16)
+        self.assertTrue((result["mean"] == array.mean(axis=-1)).all())
+        self.assertTrue((result["std"] == array.std(axis=-1)).all())
+
+    

--- a/tests/mosaic/test_datapane.py
+++ b/tests/mosaic/test_datapane.py
@@ -1,0 +1,77 @@
+"""Unittests for Datasets."""
+import os
+import shutil
+from unittest import TestCase
+
+import numpy as np
+import torch
+
+from robustnessgym.mosaic.datapane import DataPane
+from robustnessgym.mosaic import NumpyArrayColumn
+from tests.testbeds import MockTestBedv0
+
+
+class TestDataPane(TestCase):
+    def setUp(self):
+        # Arrange
+        pass
+
+    def test_from_batch(self):
+        # Build a dataset from a batch
+        datapane = DataPane.from_batch(
+            {
+                "a": [1, 2, 3],
+                "b": [True, False, True],
+                "c": ["x", "y", "z"],
+                "d": [{"e": 2}, {"e": 3}, {"e": 4}],
+                "e": torch.ones(3),
+                "f": np.ones(3),
+            },
+        )
+
+        self.assertEqual(
+            set(datapane.column_names), {"a", "b", "c", "d", "e", "f", "index"}
+        )
+        self.assertEqual(len(datapane), 3)
+    
+    def test_mixed_batched_map_return_single(self):
+        datapane = DataPane.from_batch(
+            {
+                "a": np.arange(16),
+                "b": list(np.arange(16)),
+                "c": [{"a": 2}] * 16
+            },
+        )
+
+        def func(x):
+            out = (x["a"] + np.array(x["b"])) * 2
+            return out
+
+        result = datapane.map(func, batch_size=4, batched=True)
+        self.assertTrue(isinstance(result, NumpyArrayColumn))
+        self.assertEqual(len(result), 16)
+        self.assertTrue((result == np.arange(16) * 4).all())
+    
+    def test_mixed_batched_map_return_multiple(self):
+        datapane = DataPane.from_batch(
+            {
+                "a": np.arange(16),
+                "b": list(np.arange(16)),
+                "c": [{"a": 2}] * 16
+            },
+        )
+
+        def func(x):
+            out = {
+                "x": (x["a"] + np.array(x["b"])) * 2,
+                "y": np.array([x["c"][i]["a"] for i in range(len(x["c"]))]), 
+            }
+            return out
+
+        result = datapane.map(func, batch_size=4, batched=True)
+        self.assertTrue(isinstance(result, DataPane))
+        self.assertEqual(len(result["x"]), 16)
+        self.assertEqual(len(result["y"]), 16)
+        self.assertTrue((result["x"] == np.arange(16) * 4).all())
+        self.assertTrue((result["y"] == np.ones(16) * 2).all())
+


### PR DESCRIPTION
Issues addressed: 
- [x]  We disallow columns reimplementing `batch` (an iterator), instead having them implement `get_batch(indices)`.
    - If column does **not** override `get_batch` , then assume we create batches using singletons → collate and we can put into a standard torch DataLoader. (*e.g.* `CellColumn`  , `WildsColumn` )
    - If column does override `get_batch` , then we create batches by calling `get_batch` (*i.e.* no collate) and we put it into a torch DataLoader with [automatic batching disabled](https://pytorch.org/docs/stable/data.html#disable-automatic-batching) (*e.g.* `NumpyArrayColumn` , `ArrowColumn` )
    - make easy to go from daatpane → dict and from colum → list
- [x]  Better inference of type of columns returned by `map` ?
    - Right now this is happening in `DataPane` at `_create_colum` – but this should be in a universal registry that is shared between `DataPane._create_column` and column inference after `map` and `update` type operations.
    - do an if/else or a dict that does this mapping
    - Created `from_data` class method that does this.
- [x]  Concat is now handled by writer
    - `extend` vs. `append` issue karan pointed out
        - `extend` is faster and preferred for NumPy and List returns
        - but, there are situations (*e.g.* torch.tensor) where we need to do an `append` → `concat`
    - Each ColumnType can optionally specify a `writer` which has methods `write` and `finalize` , where `finalize` takes care of the `extend` vs. `append` issue